### PR TITLE
Patch center lines

### DIFF
--- a/src/pycequeau/core/cop_processor.py
+++ b/src/pycequeau/core/cop_processor.py
@@ -405,28 +405,34 @@ class CopernicusDEMProcessor:
         dem_raster = rxr.open_rasterio(in_dem, chunks="auto").squeeze()
         wbm_raster = rxr.open_rasterio(in_wbm, chunks="auto").squeeze()
 
-        # Get ocean pixels if they exist
-        ocean_pixels = wbm_raster.where(wbm_raster == 1)
-        # Set ocean pixels to no data in the DEM
-        dem_raster = dem_raster.where(ocean_pixels.isnull(), np.nan)
+        # Treat WBM ocean pixels and WBM no-data as no-data in the DEM.
+        wbm_nodata = wbm_raster.rio.nodata
+        ocean_or_nodata = (wbm_raster == 1) | wbm_raster.isnull()
+        if wbm_nodata is not None and not np.isnan(wbm_nodata):
+            ocean_or_nodata = ocean_or_nodata | (wbm_raster == wbm_nodata)
+        dem_raster = dem_raster.where(~ocean_or_nodata, np.nan)
 
         # Now compute the surface water body areas as boolean mask
         boolean_surface_water = xr.where(wbm_raster > 1,1,np.nan)
         boolean_surface_water = xr.where(np.isnan(boolean_surface_water),1,0)
 
+        dem_crs = dem_raster.rio.crs
+        if dem_crs is None:
+            raise ValueError("Input DEM has no CRS. Cannot choose distance metric.")
+        distance_metric = "GREAT_CIRCLE" if dem_crs.is_geographic else "EUCLIDEAN"
+
         # Compute distance allocation on the surface water body areas
-        distance = xrs.proximity(boolean_surface_water, distance_metric='GREAT_CIRCLE')
+        distance = xrs.proximity(boolean_surface_water, distance_metric=distance_metric)
 
         # Reduce the proximity values by logartitmic transformation
         distance = np.log(distance + 1)/10 - 2 #Add negative 2 to make sure water areas are lower than the surroundings.
 
         # Substract the distance from the DEM
-        no_flat_dem = dem_raster - distance
+        no_flat_dem = dem_raster - distance + 1000
         no_flat_dem_path = os.path.join(base_dir, "DEM_conditioned.tif")
 
         # distance = boolean_surface_water
         # save dataset as tif
-        dem_crs = dem_raster.rio.crs
         dem_dtype = dem_raster.dtype
         # Replace the no data value in the DEM to -99999
         dem_nd = -99999

--- a/src/pycequeau/core/utils.py
+++ b/src/pycequeau/core/utils.py
@@ -56,11 +56,14 @@ def polygonize_raster(raster_name: str):
 
     Args:
         raster_name (str): _description_
+    Returns:
+        _type_: NoData value from the input raster first band.
     """
     # Open the file
     src_ds = gdal.Open(raster_name)
     # Define shp file attributes
     srcband = src_ds.GetRasterBand(1)
+    nodata_value = srcband.GetNoDataValue()
     dst_layername = 'polygonized'
     drv = ogr.GetDriverByName("ESRI Shapefile")
     # Set the export name
@@ -75,6 +78,7 @@ def polygonize_raster(raster_name: str):
     dst_layer.CreateField(fld)
     dst_field = dst_layer.GetLayerDefn().GetFieldIndex("raster_val")
     gdal.Polygonize(srcband, None, dst_layer, dst_field, [], callback=None)
+    return nodata_value
 
 
 def fix_geometry(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:

--- a/src/pycequeau/physiographic/base.py
+++ b/src/pycequeau/physiographic/base.py
@@ -776,7 +776,8 @@ class Basin:
         # Get river geometry
         geometry = CPs.get_river_geometry(self.CPfishnet, self.rtable)
         # Generate the stream network shp file and retrieve the river characteristics
-        azimuth = CPs.create_cequeau_stream_network(self.project_path, self.CPfishnet, self.rtable, 0)
+        azimuth = CPs.create_cequeau_stream_network(
+            self.project_path, self.CPfishnet, self.rtable, self._FAC, area_th=0)
         # Get the latituted and longitude centroids for each one of the CPs
         latlon_array = CPs.get_lat_lon_CP(self._CPfishnet)
         self.CPfishnet = self.CPfishnet.reindex(

--- a/src/pycequeau/physiographic/base.py
+++ b/src/pycequeau/physiographic/base.py
@@ -175,8 +175,8 @@ class Basin:
         """_summary_
         """
         # Polygonize both raster
-        u.polygonize_raster(self._Basin)
-        u.polygonize_raster(self._SubBasins)
+        no_data_basin = u.polygonize_raster(self._Basin)
+        no_data_subbasin = u.polygonize_raster(self._SubBasins)
         self._Basin = self._Basin.replace(".tif", ".shp")
         self._SubBasins = self._SubBasins.replace(".tif", ".shp")
         # Open shps as geopandas datasets
@@ -186,8 +186,8 @@ class Basin:
         watershed = u.fix_geometry(watershed)
         sub_basins = u.fix_geometry(sub_basins)
         # Drop non desired values
-        watershed = watershed.where(watershed["raster_val"] != 255)
-        sub_basins = sub_basins.where(sub_basins["raster_val"] != 255)
+        watershed = watershed.where(watershed["raster_val"] != no_data_basin)
+        sub_basins = sub_basins.where(sub_basins["raster_val"] != no_data_subbasin)
         watershed["area"] = watershed.area
         # Select the maximum value
         watershed = watershed.where(

--- a/src/pycequeau/physiographic/carreauxPartiels.py
+++ b/src/pycequeau/physiographic/carreauxPartiels.py
@@ -100,11 +100,13 @@ def get_river_geometry(CPfishnet: gpd.GeoDataFrame,
 
 def create_cequeau_stream_network(project_path: str,
                                   CP_fishnet: gpd.GeoDataFrame,
-                                  rtable: pd.DataFrame, 
+                                  rtable: pd.DataFrame,
+                                  fac_path: str,
                                   area_th=0.01) -> gpd.GeoDataFrame:
     """_summary_
 
     Args:
+        fac_path: Absolute path to the flow accumulation raster (same as Basin._FAC).
         area_th (float, optional): _description_. Defaults to 0.01.
 
     Returns:
@@ -134,7 +136,7 @@ def create_cequeau_stream_network(project_path: str,
                            index=CP_fishnet.index)
     df_line["cumulArea"] = CP_fishnet["cumulArea"].values
     # Save the outlet point of the river
-    x_outlet, y_outlet = save_outlet_point(project_path, CP_fishnet)
+    x_outlet, y_outlet = save_outlet_point(project_path, CP_fishnet, fac_path)
     # Start creating the stream files
     for i, _ in CP_fishnet.iterrows():
         # cp_aval = carreaux_partiels.loc[i, "idCPAval"]
@@ -202,11 +204,10 @@ def create_cequeau_stream_network(project_path: str,
     return gpdf_line
 
 
-def save_outlet_point(project_path: str, CP_fishnet: gpd.GeoDataFrame) -> tuple:
-    FAC_path = os.path.join(project_path,
-                            "geographic",
-                            "FAC.tif")
-    x_outlet, y_outlet = u.get_outlet_point(FAC_path)
+def save_outlet_point(project_path: str,
+                      CP_fishnet: gpd.GeoDataFrame,
+                      fac_path: str) -> tuple:
+    x_outlet, y_outlet = u.get_outlet_point(fac_path)
     point_geom = np.array([Point(x_outlet, y_outlet)], dtype=Point)
     outet_df = pd.DataFrame(data=np.array([[x_outlet, y_outlet]]),
                             columns=["x", "y"])


### PR DESCRIPTION
# Summary

This PR introduced three fixes to the physiographic and DEM preprocessing flow. The changes improve CRS-aware distance calculations, ensure raster polygonization respects the source raster's no-data value, and remove a hardcoded FAC filename when exporting the basin outlet point.

## Main changes

### 1. Use a CRS-aware distance metric during DEM conditioning

The DEM conditioning logic now checks whether the input DEM uses a geographic or projected CRS before computing proximity distances. Geographic rasters use a great-circle metric, while projected rasters use a Euclidean metric. The workflow also treats WBM no-data pixels as no-data in the DEM mask so invalid water body pixels are excluded consistently.

### 2. Keep the raster no-data value when polygonizing basin rasters

The raster polygonization helper now returns the no-data value from the source raster band. `Basin.rasterize_maps()` uses that returned value instead of assuming a fixed `255` no-data marker when filtering basin and sub-basin polygons. This makes the filtering step work with rasters that use different no-data conventions.

### 3. Remove the hardcoded FAC raster name from outlet export

The stream-network generation path now passes the configured FAC raster path into the outlet-point export helper instead of assuming the file is always named `FAC.tif` under the geographic directory. This makes outlet extraction work with project inputs that use a different FAC filename while preserving the existing workflow.